### PR TITLE
[Make It Work] Criação do caso de uso: registro de usuário e envio de email de boas-vindas

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
   validates :token, presence: true, length: { is: 36 }, uniqueness: true
   validates :password_digest, presence: true, length: { is: 64 }
 
-  after_commit :send_welcome_email
+  # after_commit :send_welcome_email
 
   private
 

--- a/app/models/user/register_and_send_welcome_email.rb
+++ b/app/models/user/register_and_send_welcome_email.rb
@@ -1,4 +1,4 @@
-class User::Register < Micro::Case
+class User::RegisterAndSendWelcomeEmail < Micro::Case
   attributes :params
 
   def call!
@@ -27,6 +27,8 @@ class User::Register < Micro::Case
         )
 
         if user.save
+          UserMailer.with(user: user).welcome.deliver_later
+
           Success result: { user: user.as_json(only: [:id, :name, :token]) }
         else
           Failure :invalid_parameters, result: { user: user.errors.as_json }

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,11 +38,13 @@ Rails.application.configure do
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
-  # config.action_mailer.delivery_method = :test
+  config.action_mailer.delivery_method = :test
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
+
+  config.active_job.queue_adapter = :test
 end

--- a/spec/models/user/register_and_send_welcome_email_spec.rb
+++ b/spec/models/user/register_and_send_welcome_email_spec.rb
@@ -1,4 +1,6 @@
-RSpec.describe User::Register do
+include ActiveJob::TestHelper
+
+RSpec.describe User::RegisterAndSendWelcomeEmail do
   context '.call' do
     context 'with invalid user params' do
       context 'without user params' do
@@ -67,7 +69,7 @@ RSpec.describe User::Register do
         params = ActionController::Parameters.new(
           user: {
             :name => 'tester',
-            :email => '123@gmail.com',
+            :email => '123@mail.com',
             :password => '1234',
             :password_confirmation => '1234'
           }
@@ -77,6 +79,21 @@ RSpec.describe User::Register do
 
         expect(result).to be_a_success
         expect(result.data[:user].keys).to match_array(["id", "name", "token"])
+      end
+
+      it 'sends a welcome email' do
+        params = ActionController::Parameters.new(
+          user: {
+            :name => 'tester',
+            :email => '123@mail.com',
+            :password => '1234',
+            :password_confirmation => '1234'
+          }
+        )
+
+        expect { 
+          described_class.call(params: params) 
+        }.to have_enqueued_mail(UserMailer, :welcome)
       end
     end
   end


### PR DESCRIPTION
Novo PR para [o caso de uso de registro de usuários](https://github.com/eliezercm/rails_app_to_refactor/pull/1) para contemplar o envio de email de boas vindas

**proto u-case**
```
User::RegisterAndSendWelcomeEmail
  name: String
  email: String
  password: String
  password_confirmation: String

Failure
  (:blank_password_or_confirmation, result: { user: })
  (:wrong_password_confirmation, result: { user: })
  (:invalid_attributes, result: { user: })
  (:missing_parameter, result: { user: })

Success
  (result: { user: })

Side effects:
  - Success: user created in the database, welcome email is sent
```